### PR TITLE
Fix for Issue 1

### DIFF
--- a/src/todo/urls.py
+++ b/src/todo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import re_path, include
+from django.urls import re_path, include
 from todo import views
 from rest_framework.routers import DefaultRouter
 

--- a/src/todo/urls.py
+++ b/src/todo/urls.py
@@ -8,6 +8,6 @@ router.register(r'todos', views.TodoItemViewSet)
 
 # The API URLs are now determined automatically by the router.
 urlpatterns = [
-  url(r'^', include(router.urls)),
+  re_path(r'^', include(router.urls)),
 ]
 

--- a/src/todo/urls.py
+++ b/src/todo/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 from todo import views
 from rest_framework.routers import DefaultRouter
 

--- a/src/todobackend/urls.py
+++ b/src/todobackend/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import re_path, include
+from django.urls import re_path, include
 from django.contrib import admin
 
 urlpatterns = [

--- a/src/todobackend/urls.py
+++ b/src/todobackend/urls.py
@@ -18,8 +18,8 @@ from django.urls import re_path, include
 from django.contrib import admin
 
 urlpatterns = [
-  url(r'^admin/', admin.site.urls),
+  re_path(r'^admin/', admin.site.urls),
 
   # Delegate routing anything from the base URL, exluding the admin path to the todo.urls class
-  url(r'^', include('todo.urls'))
+  re_path(r'^', include('todo.urls'))
   ]

--- a/src/todobackend/urls.py
+++ b/src/todobackend/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Import the include() function: from django.conf.urls import url, include
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import url, include
+from django.conf.urls import re_path, include
 from django.contrib import admin
 
 urlpatterns = [


### PR DESCRIPTION
[Guide ](https://stackoverflow.com/questions/70319606/importerror-cannot-import-name-url-from-django-conf-urls-after-upgrading-to) used to solve this issue.
